### PR TITLE
Fix minor typo in Download Center description

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -608,7 +608,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>


### PR DESCRIPTION
## Summary
- fix missing space in download description for Index.html

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879cb39f384832587740ac371791f7b