### PR TITLE
Fix 'metadata,press' phrasing

### DIFF
--- a/Fixed.html
+++ b/Fixed.html
@@ -878,7 +878,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Index.html
+++ b/Index.html
@@ -608,7 +608,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Index10.html
+++ b/Index10.html
@@ -649,7 +649,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Index11.html
+++ b/Index11.html
@@ -695,7 +695,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Index12.html
+++ b/Index12.html
@@ -763,7 +763,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Omg.html
+++ b/Omg.html
@@ -878,7 +878,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/Re.html
+++ b/Re.html
@@ -944,7 +944,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/index.html
+++ b/index.html
@@ -608,7 +608,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/index13.html
+++ b/index13.html
@@ -829,7 +829,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/index14.html
+++ b/index14.html
@@ -878,7 +878,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/index_Version2.html
+++ b/index_Version2.html
@@ -608,7 +608,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>

--- a/index_Version5.html
+++ b/index_Version5.html
@@ -470,7 +470,7 @@
             <div class="file-name">Game On! – Official Press Kit & Brand Guidelines (US/EU Version)</div>
         </a>
         <p style="font-size: 14px; margin-bottom: 14px; color: #D5D5D5;">
-          Includes high resolution images, author bio, metadata,press releases, author bios, brand identity, and everything media pros need.
+          Includes high resolution images, author bio, metadata, press releases, author bios, brand identity, and everything media pros need.
         </p>
         <div class="buttons">
           <a class="btn view-btn" href="press-kit.html" aria-label="View Game On! Press Kit page">View</a>


### PR DESCRIPTION
## Summary
- correct comma spacing after `metadata` in numerous HTML files

## Testing
- `grep -n "metadata,press" -R Index.html Index10.html Index11.html Index12.html Fixed.html Omg.html Re.html index.html index13.html index14.html index_Version2.html index_Version5.html Index9.html`


------
https://chatgpt.com/codex/tasks/task_e_6879be5b50ac8325ba1ef960fc6fcd55